### PR TITLE
scheduled eviction and graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,8 +646,7 @@ dependencies = [
 [[package]]
 name = "nbd-async"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19358d9ca85c85912bc7a84b3895d97c226dd2e1c5d6fca5adda6014e338424c"
+source = "git+https://github.com/muhamadazmy/nbd-async.git?branch=main#779695faea95f0877acfb3551a49aa83ac7f4adf"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -863,6 +862,7 @@ dependencies = [
  "sled",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "url",
 ]
 
@@ -1124,6 +1124,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.38",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ path="src/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nbd-async = "0.6.0"
+nbd-async = { git = "https://github.com/muhamadazmy/nbd-async.git", branch="main" } #"0.6.0"
 memmap2 = "0.7"
 async-trait = "0.1"
-tokio = { version = "1.29", features=["rt", "macros", "rt-multi-thread", "io-std", "fs"] }
+tokio = { version = "1.29", features=["rt", "macros", "rt-multi-thread", "io-std", "fs", "sync"] }
 thiserror = "1"
 lru = "0.12"
 crc = "3.0.1"
@@ -34,6 +34,7 @@ url = "2.4"
 nix = {version = "0.27", features = ["fs"] }
 sled = {version = "0.34", features = ["io_uring"] }
 binary-layout = "3.2"
+tokio-stream = "0.1"
 
 [build-dependencies]
 git-version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path="src/main.rs"
 nbd-async = { git = "https://github.com/muhamadazmy/nbd-async.git", branch="main" } #"0.6.0"
 memmap2 = "0.7"
 async-trait = "0.1"
-tokio = { version = "1.29", features=["rt", "macros", "rt-multi-thread", "io-std", "fs", "sync"] }
+tokio = { version = "1.29", features=["rt", "macros", "rt-multi-thread", "io-std", "fs", "sync", "signal"] }
 thiserror = "1"
 lru = "0.12"
 crc = "3.0.1"

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,5 +1,6 @@
 use crate::{cache::Cache, map::Flags, store::Store};
 use lazy_static::lazy_static;
+use nbd_async::{BlockDevice, Control};
 use prometheus::{register_histogram, register_int_counter, Histogram, IntCounter};
 use std::io;
 
@@ -169,7 +170,7 @@ where
 }
 
 #[async_trait::async_trait(?Send)]
-impl<S> nbd_async::BlockDevice for Device<S>
+impl<S> BlockDevice for Device<S>
 where
     S: Store,
 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 use anyhow::Context;
 use bytesize::ByteSize;
 use clap::{ArgAction, Parser};
+use nbd_async::NoControl;
 use qbd::{
     store::{ConcatStore, FileStore, Store},
     *,
 };
 use std::{fmt::Display, future, net::SocketAddr, path::PathBuf, str::FromStr, sync::Arc};
+
 /// This wrapper is only to overcome the default
 /// stupid format of ByteSize which uses MB/GB units instead
 /// of MiB/GiB units
@@ -119,6 +121,17 @@ async fn app(args: Args) -> anyhow::Result<()> {
         ));
     }
 
+    //let (_ctl, recv) = channel(1);
+
+    // tokio::spawn(async {
+    //     ctr
+    // });
+    // tokio::spawn(async move {
+    //     tokio::time::sleep(Duration::from_secs(10)).await;
+    //     ctl.send(nbd_async::Control::Notify(10u64)).await.unwrap();
+    //     ctl.send(nbd_async::Control::Shutdown).await.unwrap();
+    // });
+
     let nbd_bs = ByteSize::kib(4);
     nbd_async::serve_local_nbd(
         args.nbd,
@@ -126,6 +139,7 @@ async fn app(args: Args) -> anyhow::Result<()> {
         disk_size.0 / nbd_bs.0,
         false,
         device,
+        NoControl,
     )
     .await?;
 


### PR DESCRIPTION
- handle signal and shutdown gracefully (later we can do clean up)
- send an evict control message to device every 500ms
- the device can then ignore the msg if the device is under heavy load
  it only process it if the device have been ideal for over 500ms
- the eviction process should try the best it can do in only 50ms
  otherwise wait another 500ms before it get another eviction request

This will make the eviction happen continuesly in the background without
affecting IO speed much

The device can still do eviction during an IO operation if needed to be
able to load a page from persisted (slow) storage.

The device can decide to ignore the scheduled eviction
if the device is under heavy io operations.
